### PR TITLE
[main] GitHub Actions fix

### DIFF
--- a/el-maven-plugin/src/test/it/allPropertiesTest/pom.xml
+++ b/el-maven-plugin/src/test/it/allPropertiesTest/pom.xml
@@ -66,6 +66,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.12.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.eclipse.persistence</groupId>
                     <artifactId>eclipselink-testbuild-plugin</artifactId>
                     <version>1.0.1-SNAPSHOT</version>

--- a/el-maven-plugin/src/test/it/basicTest/pom.xml
+++ b/el-maven-plugin/src/test/it/basicTest/pom.xml
@@ -62,6 +62,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.12.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.eclipse.persistence</groupId>
                     <artifactId>eclipselink-testbuild-plugin</artifactId>
                     <version>1.0.1-SNAPSHOT</version>


### PR DESCRIPTION
maven-compiler-plugin definition to avoid "Source option 5 is no longer supported. Use 8 or later." message